### PR TITLE
Upgrade parent-oss POM to version 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.dataliquid</groupId>
 		<artifactId>parent-oss</artifactId>
-		<version>1.1.0</version>
+		<version>2.0.0</version>
 	</parent>
 	<groupId>com.dataliquid</groupId>
 	<artifactId>commons-xml</artifactId>


### PR DESCRIPTION
Fixes #4

## Summary
- Upgrade parent-oss POM dependency from version 1.1.0 to 2.0.0
- Ensures compatibility with latest parent POM configuration

## Changes
- Updated parent POM version in pom.xml

## Test plan
- CI workflow will verify build compatibility
- Maven build should complete successfully with new parent POM