### PR TITLE
Skip GPG plugin execution in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         cache: maven
     
     - name: Build with Maven
-      run: mvn clean compile
+      run: mvn clean compile -Dgpg.skip=true
     
     - name: Run tests
-      run: mvn test
+      run: mvn test -Dgpg.skip=true
     
     - name: Verify
-      run: mvn verify
+      run: mvn verify -Dgpg.skip=true


### PR DESCRIPTION
Fixes #8

## Summary
- Configure CI workflow to skip GPG plugin execution
- Prevent build failures due to missing GPG keys in automated builds

## Changes
- Added `-Dgpg.skip=true` flag to all Maven commands in GitHub Actions workflow
- Applied to compile, test, and verify phases

## Testing
- CI builds will now complete without requiring GPG signing
- GPG signing remains available for local builds and releases

## Notes
- GPG signing is only required when releasing artifacts to Maven Central
- This change only affects CI builds, not local development or release processes