### PR TITLE
Configure Maven batch mode and no-transfer-progress in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         cache: maven
     
     - name: Build with Maven
-      run: mvn clean compile -Dgpg.skip=true
+      run: mvn --batch-mode --no-transfer-progress clean compile -Dgpg.skip=true
     
     - name: Run tests
-      run: mvn test -Dgpg.skip=true
+      run: mvn --batch-mode --no-transfer-progress test -Dgpg.skip=true
     
     - name: Verify
-      run: mvn verify -Dgpg.skip=true
+      run: mvn --batch-mode --no-transfer-progress verify -Dgpg.skip=true


### PR DESCRIPTION
Fixes #10

## Summary
- Configure Maven to run in batch mode with reduced log verbosity in CI
- Improve CI performance and log readability

## Changes
- Added `--batch-mode` flag for non-interactive builds
- Added `--no-transfer-progress` to hide download progress
- Applied to all Maven commands (compile, test, verify)

## Benefits
- Cleaner CI logs without download progress bars
- Non-interactive mode prevents hanging on prompts
- Reduced log size for better readability
- Optimized for automated CI environments