### PR TITLE
Fix CI workflow branch names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
 
 jobs:
   test:


### PR DESCRIPTION
Fixes #12

## Summary
- Fix incorrect branch names in CI workflow configuration
- Ensure CI runs on correct branches

## Changes
- Changed branch trigger from 'main' to 'master' in GitHub Actions workflow
- Repository uses 'master' as the default branch, not 'main'

## Impact
- CI will now correctly trigger on pushes to master and develop branches
- Pull requests targeting master and develop will trigger CI checks

## Related Issue
- Fixes #12