### PR TITLE
Improve documentation with status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # commons-xml
 
+[![CI Build](https://github.com/dataliquid/commons-xml/actions/workflows/ci.yml/badge.svg)](https://github.com/dataliquid/commons-xml/actions/workflows/ci.yml)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.dataliquid/commons-xml/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.dataliquid/commons-xml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 Welcome to the `commons-xml` project! This repository contains a Java library that provides various utility classes and functions for working with XML documents. The library is designed to make common tasks related to XML processing and manipulation easier.
 
 ## Features
@@ -9,6 +13,11 @@ Welcome to the `commons-xml` project! This repository contains a Java library th
 - **XPath Support**: The library allows you to use XPath expressions to selectively access specific elements or attributes in an XML document.
 - **Validation**: You can validate XML documents against an XML schema and ensure they adhere to the specified rules.
 
+## Requirements
+
+- Java 8 or higher (supports Java 8, 11, 17, and 21)
+- Maven 3.6 or higher
+
 ## Usage
 
 To use the `commons-xml` library in your project, you can add it as a Maven dependency. Add the following section to your `pom.xml` file:
@@ -16,7 +25,7 @@ To use the `commons-xml` library in your project, you can add it as a Maven depe
 ```xml
 <dependencies>
     <dependency>
-        <groupId>com.dataliquid.commons</groupId>
+        <groupId>com.dataliquid</groupId>
         <artifactId>commons-xml</artifactId>
         <version>1.0.2</version>
     </dependency>
@@ -67,10 +76,36 @@ Please note that you need to add the `commons-xml` library to your project in or
 
 Follow this link, you will be taken to the [EXAMPLES.md](EXAMPLES.md) file where you can find more examples. These examples are intended to help you understand and utilize the functionality of the Commons-XML project.
 
-## Contribution
+## Building from Source
+
+To build the project from source:
+
+```bash
+git clone https://github.com/dataliquid/commons-xml.git
+cd commons-xml
+mvn clean install
+```
+
+## Running Tests
+
+```bash
+mvn test
+```
+
+## Contributing
+
 We welcome contributions to the commons-xml project! If you have found a bug, want to propose an improvement, or add a new feature, please follow these steps:
 
-- Fork the repository.
-- Create a new branch for your changes: git checkout -b my-feature.
-- Make your changes and run tests.
-- Commit your changes: git commit -m 'Add my feature'.
+1. Fork the repository
+2. Create a new branch for your changes: `git checkout -b feature/my-feature`
+3. Make your changes and add tests
+4. Run tests to ensure everything works: `mvn test`
+5. Commit your changes: `git commit -m 'Add my feature'`
+6. Push to your fork: `git push origin feature/my-feature`
+7. Create a Pull Request
+
+Please ensure your code follows the existing code style and includes appropriate tests.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Fixes #14

## Summary
- Enhance README with status badges matching distribution-verifier-maven-plugin style
- Add comprehensive documentation improvements
- Provide quick visual indicators of project health

## Changes
- Updated badges to match distribution-verifier-maven-plugin style:
  - GitHub Actions CI badge 
  - Maven Central badge using maven-badges.herokuapp.com
  - Apache 2.0 License badge
- Added Requirements section with Java version support (8, 11, 17, 21)
- Added Building from Source section
- Added Running Tests section
- Improved Contributing section with detailed steps
- Added License section
- Fixed Maven groupId in dependency example

## Benefits
- Consistent badge style across dataliquid projects
- Clear Java version requirements
- Better onboarding for contributors
- Professional and complete documentation