### PR TITLE
Add Gitflow workflows

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -1,0 +1,25 @@
+name: Gitflow Hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Gitflow action to perform'
+        required: true
+        type: choice
+        options:
+          - hotfix-start
+          - hotfix-finish
+      version:
+        description: 'Hotfix version (e.g., 1.17.1)'
+        required: true
+        type: string
+
+jobs:
+  hotfix:
+    uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@main
+    with:
+      action: ${{ inputs.action }}
+      version: ${{ inputs.version }}
+      java-version: '8'
+      java-distribution: 'temurin'

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -1,0 +1,25 @@
+name: Gitflow Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Gitflow action to perform'
+        required: true
+        type: choice
+        options:
+          - release-start
+          - release-finish
+      version:
+        description: 'Release version (optional for auto-detection)'
+        required: false
+        type: string
+
+jobs:
+  release:
+    uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@main
+    with:
+      action: ${{ inputs.action }}
+      version: ${{ inputs.version }}
+      java-version: '8'
+      java-distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Add gitflow-release workflow with auto-detection support for release branches
- Add gitflow-hotfix workflow for emergency fixes
- Uses reusable workflows from dataliquid/github-actions repository

## Test plan
- [ ] Verify workflows appear in Actions tab after merge
- [ ] Test release-start action creates new release branch
- [ ] Test release-finish action with auto-detection when single release branch exists
- [ ] Test hotfix-start action creates new hotfix branch
- [ ] Test hotfix-finish action merges back to master and develop