### PR TITLE
Update Gitflow workflows to use stable tag 1.0.0

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   hotfix:
-    uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@main
+    uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@1.0.0
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release:
-    uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@main
+    uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@1.0.0
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Update gitflow-release and gitflow-hotfix workflows to use stable tag 1.0.0 instead of @main
- Ensures consistent behavior across all deployments

## Benefits
- Better version stability - workflows won't change unexpectedly
- Explicit version tracking for auditing
- Follows best practices for GitHub Actions versioning

## Test plan
- [ ] Verify workflows still appear in Actions tab
- [ ] Test that manual workflow dispatch still works correctly