### PR TITLE
Add permissions to Gitflow workflows and update to stable tag

### DIFF
--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -15,9 +15,13 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   hotfix:
-    uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@main
+    uses: dataliquid/github-actions/.github/workflows/gitflow-hotfix.yml@1.0.0
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -15,9 +15,13 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
-    uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@main
+    uses: dataliquid/github-actions/.github/workflows/gitflow-release.yml@1.0.0
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Add permissions to existing Gitflow workflows for proper operation
- Add `contents: write` for branch and tag operations
- Add `pull-requests: write` for PR operations
- Update from @main to @1.0.0 for version stability

## Why this change is needed
The workflows need explicit permissions to:
- Create and push branches
- Create and push tags
- Potentially create or modify pull requests

Also updates to use the stable 1.0.0 tag instead of @main for consistent behavior.

## Test plan
- [ ] Verify workflows can create branches with release-start/hotfix-start
- [ ] Verify workflows can push changes and tags with release-finish/hotfix-finish
- [ ] Ensure no permission errors occur during workflow execution