### PR TITLE
#41 Update to maven.compiler.release property and adjust CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '17', '21' ]
     
     name: Java ${{ matrix.java }}
     

--- a/.github/workflows/gitflow-hotfix.yml
+++ b/.github/workflows/gitflow-hotfix.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '8'
+      java-version: '17'
       java-distribution: 'temurin'

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -25,5 +25,5 @@ jobs:
     with:
       action: ${{ inputs.action }}
       version: ${{ inputs.version }}
-      java-version: '8'
+      java-version: '17'
       java-distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.release>8</maven.compiler.release>
 		<xalan.version>2.7.3</xalan.version>
 		<saxon.version>12.8</saxon.version>
 	</properties>
@@ -116,14 +117,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Summary
- Replaced source/target 1.8 with maven.compiler.release=8
- Removed explicit maven-compiler-plugin configuration
- Updated CI pipeline to test with Java 17 and 21 only
- Updated gitflow workflows to use Java 17

## Test plan
- [x] Maven build successful with Java 8 compilation
- [x] CI pipeline passes with Java 17 and 21
- [x] Gitflow workflows work with Java 17

Closes #41