### PR TITLE
#47 Replace maven.compiler.release with source/target properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>8</maven.compiler.release>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 		<xalan.version>2.7.3</xalan.version>
 		<saxon.version>12.8</saxon.version>
 	</properties>


### PR DESCRIPTION
## Summary
- Replaced maven.compiler.release property with maven.compiler.source and maven.compiler.target properties due to a known bug

## Test plan
- [x] CI build passes
- [x] Project compiles successfully with mvn clean compile
- [x] All tests pass