### PR TITLE
Potential fix for code scanning alert no. 1: Useless parameter

### DIFF
--- a/src/main/java/com/dataliquid/commons/xml/DomUtils.java
+++ b/src/main/java/com/dataliquid/commons/xml/DomUtils.java
@@ -565,14 +565,11 @@ public class DomUtils
      *            the Node from which to delete matching Nodes
      * @param xpath
      *            the XPath expression to select Nodes for deletion
-     * @param removeWhitespace
-     *            a boolean indicating whether to remove whitespace-only Text nodes
-     *            during deletion
      * @param namespaceContext
      *            optional NamespaceContext for resolving namespace prefixes in the
      *            XPath expression
      */
-    public static void delete(Node node, String xpath, boolean removeWhitespace, NamespaceContext... namespaceContext)
+    public static void delete(Node node, String xpath, NamespaceContext... namespaceContext)
     {
         List<Node> nodes = selectNodes(node, xpath, namespaceContext);
         delete(nodes);


### PR DESCRIPTION
Potential fix for [https://github.com/dataliquid/commons-xml/security/code-scanning/1](https://github.com/dataliquid/commons-xml/security/code-scanning/1)

The best way to fix this problem is to remove the unused parameter `removeWhitespace` from the definition of the `delete` method at line 575. You should also update its Javadoc comment to remove any mention of the removed parameter. Finally, you must search for all direct calls to this method within the provided code and update the call signatures by removing the `removeWhitespace` argument, if any such calls exist in the shown code (in the snippet provided, no calls to this overload are shown, so no changes to call sites within the provided region are required). No imports or further changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
