### PR TITLE
Security: Upgrade commons-lang to commons-lang3 v3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.saxon</groupId>

--- a/src/main/java/com/dataliquid/commons/xml/DomUtils.java
+++ b/src/main/java/com/dataliquid/commons/xml/DomUtils.java
@@ -53,8 +53,8 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;

--- a/src/main/java/com/dataliquid/commons/xml/ns/DefaultNamespaceContext.java
+++ b/src/main/java/com/dataliquid/commons/xml/ns/DefaultNamespaceContext.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A default implementation of the NamespaceContext interface.


### PR DESCRIPTION
## Summary
- Upgrades from vulnerable `commons-lang:2.6` to secure `commons-lang3:3.18.0`
- Fixes Dependabot security alert #2 (CVE in commons-lang 2.x)
- Updates all import statements to use new package structure

## Security Issue
The project was using `commons-lang:2.6` which has a known moderate severity vulnerability. There is no patched version available for commons-lang 2.x, so the upgrade to commons-lang3 is required.

## Changes
- Updated Maven dependency from `commons-lang:2.6` to `org.apache.commons:commons-lang3:3.18.0`
- Updated imports in `DomUtils.java` and `DefaultNamespaceContext.java` from `org.apache.commons.lang` to `org.apache.commons.lang3`

## Test Plan
- [x] Build passes successfully
- [x] All 86 unit tests pass
- [x] No functional changes, only library upgrade
- [x] PMD code quality checks pass