### PR TITLE
#52 Fix incorrect and incomplete Javadoc documentation

### DIFF
--- a/src/main/java/com/dataliquid/commons/xml/DomUtils.java
+++ b/src/main/java/com/dataliquid/commons/xml/DomUtils.java
@@ -302,7 +302,7 @@ public class DomUtils
      * Creates a new Document object.
      *
      * @return the newly created Document object
-     * @throws IllegalArgumentException
+     * @throws IllegalStateException
      *             if the document cannot be created
      */
     public static Document createDocument()
@@ -328,8 +328,6 @@ public class DomUtils
      * @param documentElement
      *            the document element node to set as the root of the document
      * @return the newly created Document object
-     * @throws IllegalArgumentException
-     *             if the document cannot be created
      */
     public static Document createDocument(Node documentElement)
     {
@@ -739,8 +737,9 @@ public class DomUtils
      *            optional NamespaceContext for resolving namespace prefixes in the
      *            XPath expression
      * @param <T>
-     *            the type of object returned by the NodeProcessorParameterized
-     * @return the result of the NodeProcessorParameterized for each matching Node
+     *            the type of the parameter object passed to and returned by the
+     *            NodeProcessorParameterized
+     * @return the modified parameter object after processing all matching nodes
      */
     public static <T> T iterate(Node node, String xPath, NodeProcessorParameterized<T> nodeProcessor, T param,
             NamespaceContext... namespaceContext)
@@ -1352,7 +1351,7 @@ public class DomUtils
      *            the Writer to which the XML should be written
      * @param outputProperties
      *            the properties specifying the output format of the XML
-     * @throws IllegalArgumentException
+     * @throws RuntimeException
      *             if the XML cannot be written
      */
     public static void write(Node node, Writer writer, Properties outputProperties)
@@ -1452,7 +1451,8 @@ public class DomUtils
     }
 
     /**
-     * Dumps the XML representation of the given Node to the console.
+     * Dumps the XML representation of the given Node to the console for debugging
+     * purposes.
      *
      * @param node
      *            the Node to dump

--- a/src/main/java/com/dataliquid/commons/xml/ns/DefaultNamespaceContext.java
+++ b/src/main/java/com/dataliquid/commons/xml/ns/DefaultNamespaceContext.java
@@ -74,8 +74,8 @@ public class DefaultNamespaceContext implements javax.xml.namespace.NamespaceCon
      *
      * @param prefix
      *            the prefix for which to retrieve the namespace URI
-     * @return the namespace URI bound to the given prefix, or the DEFAULT_NS if not
-     *         found
+     * @return the namespace URI bound to the given prefix, or DEFAULT_NS if prefix
+     *         is empty/null, or null if the prefix is not found
      */
     @Override
     public String getNamespaceURI(String prefix)


### PR DESCRIPTION
## Summary
- Fixed incorrect @throws annotations to match actual exception types
- Corrected misleading @return descriptions
- Improved accuracy of parameter descriptions

## Issues Fixed
1. **DomUtils.java**:
   - `createDocument()` - Fixed @throws from IllegalArgumentException to IllegalStateException
   - `createDocument(Node)` - Removed incorrect @throws IllegalArgumentException
   - `iterate()` with NodeProcessorParameterized - Corrected @return description
   - `write()` - Fixed @throws from IllegalArgumentException to RuntimeException
   - `dump()` - Added clarification that it's for debugging purposes

2. **DefaultNamespaceContext.java**:
   - `getNamespaceURI()` - Corrected @return description to accurately describe behavior

## Test Plan
- [x] All existing unit tests pass (86 tests)
- [x] Build successful with no compilation errors
- [x] PMD code quality checks pass
- [x] Javadoc changes are documentation-only, no functional changes

Fixes #52