### PR TITLE
#30 Fix deprecated StringUtils.equalsIgnoreCase method

### DIFF
--- a/src/main/java/com/dataliquid/commons/xml/DomUtils.java
+++ b/src/main/java/com/dataliquid/commons/xml/DomUtils.java
@@ -54,6 +54,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.Comment;
@@ -1565,7 +1566,7 @@ public class DomUtils
      */
     public static void renameAll(Node node, String from, String to)
     {
-        if (StringUtils.equalsIgnoreCase(node.getNodeName(), from))
+        if (Strings.CI.equals(node.getNodeName(), from))
         {
             renameNode(node, to);
         }


### PR DESCRIPTION
## Summary
- Replaced deprecated `StringUtils.equalsIgnoreCase()` with `Strings.CI.equals()` as recommended by Apache Commons Lang3 v3.18.0
- This fixes the security scanning alert #30 about using deprecated methods

## Test plan
- [x] Code compiles successfully with `mvn clean compile`
- [x] No new warnings introduced
- [x] The `Strings.CI.equals()` method provides the same null-safe, case-insensitive comparison functionality